### PR TITLE
Fix probabilistic wrong-password detection

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -187,6 +187,12 @@ Bug fixes
   was dropped with no exception and no partial file. Most likely to bite when the settings
   variable is not touched again before the scope closes, which the JIT may treat as the
   object being dead.
+- Encryption: a wrong password is now reliably reported as a wrong password. Detection
+  relied on the padding check alone, which accepts wrong-key output by chance about once in
+  256 attempts; when it did, the failure surfaced as "Unable to parse file" with a JSON
+  reader error, pointing at file corruption rather than at the password. The decrypted
+  payload is now also checked for being valid UTF-8. This is a better diagnostic, not an
+  integrity guarantee, and the on-disk format is unchanged.
 - Encryption: fixed a truncated-read defect. The initialization vector was read without
   checking how many bytes came back, so a short read left part of the IV zeroed and
   produced garbage plaintext or a misleading padding error rather than failing. Files too

--- a/src/JsonSettings/Modulation/RijndaelModule.cs
+++ b/src/JsonSettings/Modulation/RijndaelModule.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Security;
 using System.Security.Cryptography;
+using System.Text;
 using Rijndael256;
 using Rijndael = Rijndael256.Rijndael;
 
@@ -63,6 +64,43 @@ namespace Nucs.JsonSettings.Modulation {
                 data = Rijndael.DecryptBytes(data, Password.ToRawString(), KeySize);
             } catch (CryptographicException inner) {
                 throw new JsonSettingsException("Password appears to be invalid.", inner);
+            }
+
+            //A CryptographicException alone is not a reliable wrong-password signal. CBC
+            //decryption with the wrong key yields random bytes, and PKCS7 padding validation
+            //accepts those by chance roughly once in 256 attempts - measured at 0.40% over 3000
+            //wrong-password loads. When it does, decryption "succeeds", the garbage reaches the
+            //JSON parser, and the user is told "Unable to parse file" with a
+            //JsonReaderException about an unexpected character, which points at file corruption
+            //rather than at the password they actually got wrong.
+            //
+            //What this library encrypts is always UTF-8 JSON, so plaintext that is not even
+            //valid UTF-8 did not come from this password. That closes almost all of the
+            //remaining gap: random bytes surviving both the padding check and UTF-8 validation
+            //is vanishingly unlikely.
+            //
+            //This is a diagnostic improvement, not an integrity guarantee - only an
+            //authenticated construction would be that, and switching to one would change the
+            //on-disk format and make every existing encrypted file unreadable.
+            if (!IsValidUtf8(data))
+                throw new JsonSettingsException("Password appears to be invalid.");
+        }
+
+        /// <summary>
+        ///     True when <paramref name="data"/> decodes as UTF-8 without invalid sequences.
+        /// </summary>
+        private static bool IsValidUtf8(byte[] data) {
+            if (data == null || data.Length == 0)
+                return true;
+
+            try {
+                //GetCharCount rather than GetString: it performs the same validation without
+                //allocating a string that is immediately discarded.
+                new UTF8Encoding(false, true).GetCharCount(data);
+                return true;
+            } catch (ArgumentException) {
+                //DecoderFallbackException derives from ArgumentException.
+                return false;
             }
         }
     }

--- a/tests/JsonSettings.Tests/EncryptionCompatibilityTests.cs
+++ b/tests/JsonSettings.Tests/EncryptionCompatibilityTests.cs
@@ -101,6 +101,44 @@ namespace Nucs.JsonSettings.Tests {
                 .Should().Throw<Exception>("a file too short to hold an IV cannot be decrypted");
         }
 
+        /// <summary>
+        ///     A wrong password whose decryption happens to survive padding validation must still
+        ///     be reported as a wrong password.
+        /// </summary>
+        /// <remarks>
+        ///     Detection used to rest entirely on the CryptographicException raised by PKCS7
+        ///     padding validation, which is a probabilistic signal: CBC decryption under the
+        ///     wrong key yields random bytes whose final block is valid padding by chance about
+        ///     once in 256 attempts - measured at 0.40% over 3000 loads. In those cases
+        ///     decryption "succeeded", garbage reached the JSON parser, and the caller was told
+        ///     "Unable to parse file" with a JsonReaderException about an unexpected character.
+        ///     That reads as a corrupt file rather than a mistyped password, which is the one
+        ///     thing the message needed to convey.
+        ///
+        ///     Not hypothetical: it surfaced as a red CI run, on one framework out of five, in
+        ///     SettingsBag_InvalidPassword.
+        ///
+        ///     "p433" is not arbitrary. It was found by searching wrong passwords against the
+        ///     fixture above for one whose decryption passes padding validation, so this hits the
+        ///     0.4% branch on EVERY run instead of once in 256. Both AES and PBKDF2 are
+        ///     deterministic functions of key and input, so the collision reproduces identically
+        ///     on every framework and platform - including across the three different KDF APIs
+        ///     Hash.Pbkdf2 uses. Verified failing against the unfixed library, where it reports
+        ///     the parse error quoted above.
+        /// </remarks>
+        [TestMethod]
+        public void ReportsAWrongPasswordAsAWrongPasswordEvenWhenPaddingValidates() {
+            using var f = new TempFile();
+            File.WriteAllBytes(f.FileName, Convert.FromBase64String(PreExistingCiphertextBase64));
+
+            new Action(() => JsonSettings.Configure<CompatSettings>(f.FileName)
+                                         .WithEncryption("p433")
+                                         .LoadNow())
+                .Should().Throw<JsonSettingsException>()
+                .Where(e => e.Message.StartsWith("Password", StringComparison.OrdinalIgnoreCase),
+                       "a wrong password must blame the password, not the file contents");
+        }
+
         public class CompatSettings : JsonSettings {
             public override string FileName { get; set; }
             public string Value { get; set; }


### PR DESCRIPTION
The 2.1.0 release dry run failed on `SettingsBag_InvalidPassword`. Wrong-password detection relied solely on PKCS7 padding validation, which accepts wrong-key output ~0.4% of the time (measured), surfacing as a JSON parse error instead. Adds a UTF-8 validity check on the decrypted payload. On-disk format unchanged; regression test is deterministic.