### PR TITLE
Fix pack failing from a clean tree (NU5026)

### DIFF
--- a/src/JsonSettings.Autosave/JsonSettings.Autosave.csproj
+++ b/src/JsonSettings.Autosave/JsonSettings.Autosave.csproj
@@ -2,12 +2,14 @@
 
   <PropertyGroup>
 	  <Summary>An extension to JsonSettings that allows to wrap a class via transparent proxy that autosaves. Support for Autosaving on INotifyPropertyChanged/INotifyCollectionChanged.</Summary>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>An extension to JsonSettings that allows to wrap a class via transparent proxy that autosaves. Support for Autosaving on INotifyPropertyChanged/INotifyCollectionChanged.</Description>
     <TargetFrameworks>netstandard2.0;net48;net6.0;net8.0;net10.0</TargetFrameworks>
     <RootNamespace>Nucs.JsonSettings.Autosave</RootNamespace>
     <PackageId>Nucs.JsonSettings.Autosave</PackageId>
     <Title>Nucs.JsonSettings.Autosave</Title>
+    <!-- GeneratePackageOnBuild is deliberately absent; see the note in JsonSettings.csproj.
+         In short: on a multi-targeted project it makes `dotnet pack` from a clean tree fail
+         with NU5026, and packaging is the release pipeline's job. -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/JsonSettings/JsonSettings.csproj
+++ b/src/JsonSettings/JsonSettings.csproj
@@ -3,7 +3,6 @@
     <TargetFrameworks>netstandard2.0;net48;net6.0;net8.0;net10.0</TargetFrameworks>
 	<Summary>Easiest way you'll ever write settings for your app. Cross-platform, modular and still a one-liner.
 Encrypt, Encode and have full control over hardcoded / dynamic settings.</Summary>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Easiest way you'll ever write settings for your app. This library is built to be modular and one-liner exploiting the powerful serialization capabilities of Json.NET out of the box without any mapping necessary to serialize nested custom objects, dictionaries and lists.</Description>
     <RootNamespace>Nucs.JsonSettings</RootNamespace>
     <PackageId>Nucs.JsonSettings</PackageId>
@@ -15,6 +14,12 @@ Encrypt, Encode and have full control over hardcoded / dynamic settings.</Summar
     <LangVersion>9.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- GeneratePackageOnBuild is deliberately absent. On a multi-targeted project it hooks
+         Pack into the build, and the hooked Pack runs before every inner target framework has
+         written its assembly, so `dotnet pack` from a clean tree fails with NU5026 reporting
+         that a target framework's assembly "was not found on disk". Packaging is the release
+         pipeline's job and it packs explicitly; a developer build has no reason to emit
+         .nupkg files into bin/ as a side effect. -->
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Autosave\**" />


### PR DESCRIPTION
The 2.1.0 dry run failed in `pack` with NU5026. `GeneratePackageOnBuild` hooks Pack into Build, and on a multi-targeted project it runs before every inner TFM has written its assembly. Reproduces deterministically from a wiped bin/obj. Removing it also stops developer builds emitting .nupkg into bin/.