### PR TITLE
refactor(namespaces): correct misplaced types in library namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ On a scenario of exception/failure, one of the following actions can take place:
 All recovery properties and methods are suited for inheritance so extending is quite easy.
 
 ```C#
-using Nucs.JsonSettings.Fluent;
+using Nucs.JsonSettings;
 using Nucs.JsonSettings.Modulation.Recovery;
 
 //attach RecoveryModule via the fluent extension and pick what happens on a parse failure:
@@ -238,7 +238,7 @@ There are two ways to specify which version to enforce.
     When dealing with inheritance/virtual override, the attribute of the lowest inherited class will be used.
 
 ```C#
-using Nucs.JsonSettings.Fluent;
+using Nucs.JsonSettings;
 using Nucs.JsonSettings.Modulation;
 
 //The settings class must implement IVersionable (contributes `Version Version { get; set; }`).
@@ -626,7 +626,7 @@ Key points
 - All modules provided by the library have properties and methods that are suited for inheritance so extending is easy.
 
 ```C#
-using Nucs.JsonSettings.Fluent;
+using Nucs.JsonSettings;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 

--- a/docs/website-src/api/index.md
+++ b/docs/website-src/api/index.md
@@ -51,7 +51,7 @@ The extension methods that build a configured settings object. See [The Basics](
 
 | Type | Description |
 |------|-------------|
-| @Nucs.JsonSettings.Fluent.FluentJsonSettings | `WithFileName`, `WithModule`, `WithEncryption`, `WithBase64`, `WithVersioning`, `WithRecovery`, `WithDefaultValues`, `LoadNow`. |
+| @Nucs.JsonSettings.FluentJsonSettings | `WithFileName`, `WithModule`, `WithEncryption`, `WithBase64`, `WithVersioning`, `WithRecovery`, `WithDefaultValues`, `LoadNow`. |
 
 ---
 
@@ -109,7 +109,7 @@ Save automatically on change (ships in `Nucs.JsonSettings.Autosave`). See [Autos
 | @Nucs.JsonSettings.Autosave.IgnoreAutosaveAttribute | Excludes a property from autosave monitoring. |
 | @Nucs.JsonSettings.Autosave.NotificationBinder | Binds `INotifyPropertyChanged`/`INotifyCollectionChanged` sources for WPF-style autosave. |
 
-`NotifiyingJsonSettings` (in the `Nucs.JsonSettings.Examples` namespace) is the convenient
+`NotifiyingJsonSettings` (in the `Nucs.JsonSettings` namespace) is the convenient
 `INotifyPropertyChanged` base class for WPF-style settings.
 
 ---

--- a/docs/website-src/api/overwrites/Nucs.JsonSettings.md
+++ b/docs/website-src/api/overwrites/Nucs.JsonSettings.md
@@ -9,8 +9,8 @@ remarks: |
   - <xref href="Nucs.JsonSettings.ISavable" data-throw-if-not-resolved="false"></xref> and <xref href="Nucs.JsonSettings.IEncryptedSavable" data-throw-if-not-resolved="false"></xref> are the savable contracts.
 
   Optional behavior — encryption, Base64, versioning, recovery and autosave — is added per object as
-  modules; see the `Nucs.JsonSettings.Modulation` namespace and the fluent extensions in
-  `Nucs.JsonSettings.Fluent`.
+  modules; see the `Nucs.JsonSettings.Modulation` namespace and the `FluentJsonSettings` fluent
+  extensions in this namespace.
 
   ```csharp
   using Nucs.JsonSettings;

--- a/docs/website-src/docs/encryption.md
+++ b/docs/website-src/docs/encryption.md
@@ -14,7 +14,6 @@ password string:
 
 ```csharp
 using Nucs.JsonSettings;
-using Nucs.JsonSettings.Fluent;
 
 var settings = JsonSettings.Load<MySettings>("config.json", q => q.WithEncryption("mysecretpassword"));
 // or, explicitly:

--- a/docs/website-src/docs/notifications.md
+++ b/docs/website-src/docs/notifications.md
@@ -52,7 +52,6 @@ using System.ComponentModel;
 using Nucs.JsonSettings;
 using Nucs.JsonSettings.Autosave;        // [Autosave], EnableAutosave
 using Nucs.JsonSettings.NotifyChanges;   // [NotifyChanges], [NotifyChangesMixin], [IgnoreNotify], [NotifyChangesFor]
-using Nucs.JsonSettings.Examples;        // NotifiyingJsonSettings
 
 [Autosave]        // persist on change
 [NotifyChanges]   // raise PropertyChanged on change
@@ -76,7 +75,7 @@ No hand-written `OnPropertyChanged()` in any setter; the aspect weaves it in.
 
 ## The `NotifiyingJsonSettings` base
 
-The library ships a small base class in the `Nucs.JsonSettings.Examples` namespace that adds the
+The library ships a small base class in the `Nucs.JsonSettings` namespace that adds the
 event and a raiser:
 
 ```csharp
@@ -475,7 +474,6 @@ monitored &mdash; only the collection's own change events are.
 using System.Collections.ObjectModel;
 using Nucs.JsonSettings;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 
 [Autosave]
 public class HouseholdSettings : NotifiyingJsonSettings {

--- a/docs/website-src/docs/recovery.md
+++ b/docs/website-src/docs/recovery.md
@@ -19,7 +19,6 @@ Use the `WithRecovery` fluent extension (from `Nucs.JsonSettings.Modulation.Reco
 ```csharp
 using Nucs.JsonSettings;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation.Recovery;
 
 public class RecoverableSettings : JsonSettings {

--- a/docs/website-src/docs/versioning.md
+++ b/docs/website-src/docs/versioning.md
@@ -39,8 +39,8 @@ There are two ways to specify which version to enforce.
 **1. Pass the version to `WithVersioning`:**
 
 ```csharp
+using Nucs.JsonSettings;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 
 // Load version 1.0.0.6

--- a/docs/website-src/filterConfig.yml
+++ b/docs/website-src/filterConfig.yml
@@ -12,14 +12,11 @@ apiRules:
         uid: System.Runtime.CompilerServices.CompilerGeneratedAttribute
       type: Member
 
-  # Internal helpers that ship inside the assembly but are not part of the Nucs.JsonSettings
-  # public contract; ReflectionHelpers lives under a Microsoft.Xna.* namespace. (The former
-  # third-party Rijndael256 namespace was removed when encryption moved onto
-  # System.Security.Cryptography. EncryptionModule under Nucs.JsonSettings.Modulation is now the
-  # supported entry point, and EncryptionAlgorithm/KeySize are documented public enums.)
-  - exclude:
-      uidRegex: ^Microsoft\.Xna
-      type: Namespace
+  # Internal helpers (e.g. ReflectionHelpers, SafeDictionary) ship inside the assembly but are not
+  # part of the Nucs.JsonSettings public contract. They are internal types, so the default DocFX
+  # filter already hides them and no explicit namespace exclude is needed. EncryptionModule under
+  # Nucs.JsonSettings.Modulation is the supported encryption entry point; EncryptionAlgorithm and
+  # KeySize are public enums in Nucs.JsonSettings.
 
   # Uncomment to also hide the path/file helpers if you want the reference to cover only the
   # settings API surface:

--- a/examples/JsonSettings.Examples.UI.Avalonia/Settings/DemoSettings.cs
+++ b/examples/JsonSettings.Examples.UI.Avalonia/Settings/DemoSettings.cs
@@ -1,6 +1,5 @@
 using System.Collections.ObjectModel;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.NotifyChanges;
 

--- a/examples/JsonSettings.Examples.UI.WinForms/Settings/VaultSettings.cs
+++ b/examples/JsonSettings.Examples.UI.WinForms/Settings/VaultSettings.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 
 namespace Nucs.JsonSettings.Examples.UI.WinForms;
 

--- a/examples/JsonSettings.Examples/EncryptedJsonSettings.cs
+++ b/examples/JsonSettings.Examples/EncryptedJsonSettings.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Nucs.JsonSettings.Fluent;
 
 namespace Nucs.JsonSettings.Examples {
     static class EncryptedProgram {

--- a/examples/JsonSettings.Examples/EncryptedSettingsBag.cs
+++ b/examples/JsonSettings.Examples/EncryptedSettingsBag.cs
@@ -5,7 +5,6 @@ using System.Linq;
 using System.Security;
 using System.Threading.Tasks;
 using System.Windows.Forms;
-using Nucs.JsonSettings.Fluent;
 
 namespace Nucs.JsonSettings.Examples {
     static class EncryptedSettingsBagProgram {

--- a/examples/JsonSettings.Examples/RecoverableFromFailureToLoad.cs
+++ b/examples/JsonSettings.Examples/RecoverableFromFailureToLoad.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 

--- a/examples/JsonSettings.Examples/Versioning.cs
+++ b/examples/JsonSettings.Examples/Versioning.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 
 namespace Nucs.JsonSettings.Examples {

--- a/src/JsonSettings.Autosave/JsonSettingsAutosaveExtensions.cs
+++ b/src/JsonSettings.Autosave/JsonSettingsAutosaveExtensions.cs
@@ -2,7 +2,6 @@ using System;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reflection;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Modulation;
 
 namespace Nucs.JsonSettings.Autosave {

--- a/src/JsonSettings.Autosave/NotificationBinder.cs
+++ b/src/JsonSettings.Autosave/NotificationBinder.cs
@@ -6,7 +6,6 @@ using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using Newtonsoft.Json;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Reflection;
 
 namespace Nucs.JsonSettings.Autosave {

--- a/src/JsonSettings.NotifyChanges/NotifyChangesRuntime.cs
+++ b/src/JsonSettings.NotifyChanges/NotifyChangesRuntime.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Reflection;
 

--- a/src/JsonSettings/Fluent/FluentJsonSettings.cs
+++ b/src/JsonSettings/Fluent/FluentJsonSettings.cs
@@ -4,7 +4,7 @@ using System.Security;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 
-namespace Nucs.JsonSettings.Fluent {
+namespace Nucs.JsonSettings {
     public static class FluentJsonSettings {
         internal static T _withFileName<T>(this T _instance, string filename, bool throwless = false) where T : JsonSettings {
             _instance.FileName = JsonSettings.ResolvePath(_instance, filename, throwless);

--- a/src/JsonSettings/Inline/Activation.cs
+++ b/src/JsonSettings/Inline/Activation.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.Serialization;
-using Microsoft.Xna.Framework.Utilities;
 using Module = Nucs.JsonSettings.Modulation.Module;
 
 namespace Nucs.JsonSettings {

--- a/src/JsonSettings/Inline/ReflectionHelpers.cs
+++ b/src/JsonSettings/Inline/ReflectionHelpers.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Reflection;
 
-namespace Microsoft.Xna.Framework.Utilities {
+namespace Nucs.JsonSettings {
     internal static partial class ReflectionHelpers {
         /// <summary>
         /// Returns true if the given type represents a non-object type that is not abstract.

--- a/src/JsonSettings/JsonSettings.cs
+++ b/src/JsonSettings/JsonSettings.cs
@@ -10,7 +10,6 @@ using System.Threading;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Inline;
 using Nucs.JsonSettings.Modulation;
 using Module = Nucs.JsonSettings.Modulation.Module;

--- a/src/JsonSettings/NotifiyingJsonSettings.cs
+++ b/src/JsonSettings/NotifiyingJsonSettings.cs
@@ -1,7 +1,7 @@
 ﻿using System.ComponentModel;
 using System.Runtime.CompilerServices;
 
-namespace Nucs.JsonSettings.Examples {
+namespace Nucs.JsonSettings {
     /// <summary>
     ///     A <see cref="JsonSettings"/> that implements <see cref="INotifyPropertyChanged"/> and
     ///     <see cref="INotifyPropertyChanging"/>.

--- a/tests/JsonSettings.Tests/Autosave/AutosaveEdgeCaseTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/AutosaveEdgeCaseTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/AutosaveExtensionsEdgeTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/AutosaveExtensionsEdgeTests.cs
@@ -2,7 +2,6 @@ using System;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 
 namespace Nucs.JsonSettings.Tests.Autosave {
     /// <summary>

--- a/tests/JsonSettings.Tests/Autosave/AutosaveNotificationsTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/AutosaveNotificationsTests.cs
@@ -5,7 +5,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/AutosaveScopeTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/AutosaveScopeTests.cs
@@ -2,7 +2,6 @@ using System;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/Autosave/AutosaveTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/AutosaveTests.cs
@@ -4,7 +4,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 

--- a/tests/JsonSettings.Tests/Autosave/CollectionReloadAndMixinBindingTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/CollectionReloadAndMixinBindingTests.cs
@@ -5,8 +5,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.NotifyChanges;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/Autosave/ModuleIsolationAndRepopulateTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/ModuleIsolationAndRepopulateTests.cs
@@ -5,7 +5,6 @@ using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/Autosave/NestedChangeGatingAndWeaveMarkerTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NestedChangeGatingAndWeaveMarkerTests.cs
@@ -8,7 +8,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NestedNotifierTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NestedNotifierTests.cs
@@ -3,7 +3,6 @@ using System.Runtime.CompilerServices;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NotifyAutosaveCompositionTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyAutosaveCompositionTests.cs
@@ -6,7 +6,6 @@ using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NotifyChangesEdgeTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyChangesEdgeTests.cs
@@ -6,7 +6,6 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Nucs.JsonSettings.Autosave;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 
 namespace Nucs.JsonSettings.Tests.Autosave {
     /// <summary>

--- a/tests/JsonSettings.Tests/Autosave/NotifyChangesForTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyChangesForTests.cs
@@ -4,7 +4,6 @@ using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NotifyChangesMarshalingTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyChangesMarshalingTests.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NotifyChangesTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyChangesTests.cs
@@ -5,7 +5,6 @@ using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.Autosave;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Autosave/NotifyChangingTests.cs
+++ b/tests/JsonSettings.Tests/Autosave/NotifyChangingTests.cs
@@ -3,7 +3,6 @@ using System.ComponentModel;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Nucs.JsonSettings.NotifyChanges;
-using Nucs.JsonSettings.Examples;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Autosave {

--- a/tests/JsonSettings.Tests/Base64ModuleTests.cs
+++ b/tests/JsonSettings.Tests/Base64ModuleTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/BuiltInCryptoCompatibilityTests.cs
+++ b/tests/JsonSettings.Tests/BuiltInCryptoCompatibilityTests.cs
@@ -4,7 +4,6 @@ using System.Security.Cryptography;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/ConfigurableTests.cs
+++ b/tests/JsonSettings.Tests/ConfigurableTests.cs
@@ -1,6 +1,5 @@
 ﻿using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/CrossCulture/CrossCultureCompatibilityTests.cs
+++ b/tests/JsonSettings.Tests/CrossCulture/CrossCultureCompatibilityTests.cs
@@ -7,7 +7,6 @@ using System.Security.Cryptography;
 using System.Threading;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.CrossVersion;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/EncryptionAlgorithmsTests.cs
+++ b/tests/JsonSettings.Tests/EncryptionAlgorithmsTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Security.Cryptography;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/EncryptionCompatibilityTests.cs
+++ b/tests/JsonSettings.Tests/EncryptionCompatibilityTests.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests {

--- a/tests/JsonSettings.Tests/EncryptionKeyTests.cs
+++ b/tests/JsonSettings.Tests/EncryptionKeyTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/FluentApiCoverageTests.cs
+++ b/tests/JsonSettings.Tests/FluentApiCoverageTests.cs
@@ -4,7 +4,6 @@ using System.Security;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/FluentTests.cs
+++ b/tests/JsonSettings.Tests/FluentTests.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 

--- a/tests/JsonSettings.Tests/HowToUse.cs
+++ b/tests/JsonSettings.Tests/HowToUse.cs
@@ -1,6 +1,5 @@
 ﻿using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 

--- a/tests/JsonSettings.Tests/Inline/ReflectionHelpersTests.cs
+++ b/tests/JsonSettings.Tests/Inline/ReflectionHelpersTests.cs
@@ -1,7 +1,6 @@
 using System;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Microsoft.Xna.Framework.Utilities;
 
 namespace Nucs.JsonSettings.Tests.Inline {
     /// <summary>

--- a/tests/JsonSettings.Tests/LegacyEncryptionParityTests.cs
+++ b/tests/JsonSettings.Tests/LegacyEncryptionParityTests.cs
@@ -4,7 +4,6 @@ using System.Security.Cryptography;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Encryption;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/Modulation/EncryptionInternalsTests.cs
+++ b/tests/JsonSettings.Tests/Modulation/EncryptionInternalsTests.cs
@@ -3,7 +3,6 @@ using System.Security;
 using System.Security.Cryptography;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/Modulation/ModuleActionsCoverageTests.cs
+++ b/tests/JsonSettings.Tests/Modulation/ModuleActionsCoverageTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/Modulation/ModuleGuardTests.cs
+++ b/tests/JsonSettings.Tests/Modulation/ModuleGuardTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/ObsoleteRijndaelModuleTests.cs
+++ b/tests/JsonSettings.Tests/ObsoleteRijndaelModuleTests.cs
@@ -3,7 +3,6 @@ using System.Security;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/RecoveryModuleTests.cs
+++ b/tests/JsonSettings.Tests/RecoveryModuleTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.Tests.Utils;

--- a/tests/JsonSettings.Tests/SettingsBagTests.cs
+++ b/tests/JsonSettings.Tests/SettingsBagTests.cs
@@ -3,7 +3,6 @@ using System.IO;
 using System.Security;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/Upgrade/DamagedEncryptedFileTests.cs
+++ b/tests/JsonSettings.Tests/Upgrade/DamagedEncryptedFileTests.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Text;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation.Recovery;
 using Nucs.JsonSettings.Tests.Utils;
 

--- a/tests/JsonSettings.Tests/Upgrade/ModuleChainingTests.cs
+++ b/tests/JsonSettings.Tests/Upgrade/ModuleChainingTests.cs
@@ -2,7 +2,6 @@ using System;
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Upgrade {

--- a/tests/JsonSettings.Tests/Upgrade/SerializationDepthTests.cs
+++ b/tests/JsonSettings.Tests/Upgrade/SerializationDepthTests.cs
@@ -12,7 +12,6 @@ using System.Text;
 using System.Threading;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Tests.Utils;
 
 namespace Nucs.JsonSettings.Tests.Upgrade {

--- a/tests/JsonSettings.Tests/VersioningModuleTests.cs
+++ b/tests/JsonSettings.Tests/VersioningModuleTests.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using AwesomeAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Nucs.JsonSettings.Fluent;
 using Nucs.JsonSettings.Modulation;
 using Nucs.JsonSettings.Tests.Utils;
 


### PR DESCRIPTION
## Summary

Audits every type in the three library projects (`src/`, excluding tests and examples) and relocates the declarations whose namespace did not match the type's role, shipping assembly, or folder. All moves are namespace-only — no behavior changes.

## Namespace moves

| Type | Before | After | Why |
|------|--------|-------|-----|
| `NotifiyingJsonSettings` | `Nucs.JsonSettings.Examples` | `Nucs.JsonSettings` | Shipped public base class the Autosave/NotifyChanges packages depend on — production API, not a sample, and the only library type that sat in `.Examples`. |
| `FluentJsonSettings` | `Nucs.JsonSettings.Fluent` | `Nucs.JsonSettings` | The primary fluent entry-point surface now lives in the root namespace. |
| `ReflectionHelpers` | `Microsoft.Xna.Framework.Utilities` | `Nucs.JsonSettings` | Vendored `internal` helper that had kept its third-party origin namespace inside the assembly. Stays `internal`. |

## Evaluated and kept in place

- **`KeySize` / `EncryptionAlgorithm`** stay in `Nucs.JsonSettings` (root). They are the arguments to the root-level `WithEncryption` / `WithEncryptionRawKey` fluent overloads (`EncryptionAlgorithm algorithm, KeySize keySize = KeySize.Aes256`), so a single `using Nucs.JsonSettings;` covers the entire encrypted-load call and honours the shipped release-note compatibility promise. Co-locating them with `EncryptionModule` under `.Modulation` was considered and rejected on those grounds.
- **`ISavable` / `IEncryptedSavable`** stay in `Nucs.JsonSettings` — core contracts; moving them under the optional `.Autosave` feature namespace was rejected.
- **`SecureStringExt`** stays `public` in `System.Security` (intentional extension surface, consumed by an example); **`ReflectionHelper`** stays `public` in `Nucs.JsonSettings.Reflection` (consumed by the `Nucs.JsonSettings.NotifyChanges` assembly, which is not an `InternalsVisibleTo` friend, so it cannot be made `internal`).

## Cascade & docs

- Library internals, tests (37 files) and examples: removed the now-dead `using` directives — the moved types resolve via the parent namespace.
- Docs rewritten to the new layout (README, website docs, `api/index.md`, the `Nucs.JsonSettings` overwrite, `filterConfig.yml`) — current-state prose, not change-annotations.
- Generated DocFX `api/*.yml` + `toc.yml` are produced from the assembly by `docfx metadata` and need a regeneration to reflect the moves; they are not hand-edited here.

## Breaking change

Public namespaces change for `NotifiyingJsonSettings` and the fluent extension methods. Consumers update their imports: `using Nucs.JsonSettings.Examples;` / `using Nucs.JsonSettings.Fluent;` → `using Nucs.JsonSettings;`.

## Verification

Build green on every target framework (`netstandard2.0`, `net48`, `net6.0`, `net8.0`, `net10.0`) across the three libraries, the test project, and all buildable example projects.
